### PR TITLE
Use assembly location as default content root

### DIFF
--- a/Neolution.DotNet.Console.Sample/Commands/Echo/EchoCommand.cs
+++ b/Neolution.DotNet.Console.Sample/Commands/Echo/EchoCommand.cs
@@ -3,7 +3,6 @@
     using System;
     using Microsoft.Extensions.Logging;
     using Neolution.DotNet.Console.Abstractions;
-    using Neolution.DotNet.Console.Sample.Commands.Start;
 
     /// <summary>
     /// Prints the command line parameter into the console window

--- a/Neolution.DotNet.Console/DotNetConsole.cs
+++ b/Neolution.DotNet.Console/DotNetConsole.cs
@@ -1,5 +1,6 @@
 ﻿namespace Neolution.DotNet.Console
 {
+    using System;
     using System.IO;
     using System.Reflection;
     using Microsoft.Extensions.Configuration;
@@ -26,7 +27,10 @@
         {
             var builder = new ConsoleAppBuilder(args);
 
-            builder.UseContentRoot(Directory.GetCurrentDirectory());
+            var assemblyLocation = typeof(DotNetConsole).Assembly.Location;
+            var assemblyPath = Path.GetDirectoryName(assemblyLocation);
+
+            builder.UseContentRoot(assemblyPath);
             builder.ConfigureConsoleConfiguration(config =>
             {
                 config.AddEnvironmentVariables(prefix: "DOTNET_");

--- a/Neolution.DotNet.Console/DotNetConsole.cs
+++ b/Neolution.DotNet.Console/DotNetConsole.cs
@@ -1,6 +1,5 @@
 ﻿namespace Neolution.DotNet.Console
 {
-    using System;
     using System.IO;
     using System.Reflection;
     using Microsoft.Extensions.Configuration;


### PR DESCRIPTION
Using the current directory as content root prevents starting when the user runs the application from a different folder than the one which contains the assembly.

E.g., assuming application path: `C:\foo\bar\foobar.exe`

Running the application from the directory where the assemblies are in, works fine:
`C:\foo\bar> foobar.exe` 

But running the application from a different directory does not work. The application does not properly start and blocks:
`C:\bar> C:\foo\bar\foobar.exe` 

