### PR TITLE
Fix Microsoft Logging configuration section

### DIFF
--- a/Neolution.DotNet.Console.Sample/appsettings.Development.json
+++ b/Neolution.DotNet.Console.Sample/appsettings.Development.json
@@ -1,5 +1,4 @@
 {
-  "DetailedErrors": true,
   "Logging": {
     "LogLevel": {
       "Default": "Trace"

--- a/Neolution.DotNet.Console/ConsoleAppBuilderExtensions.cs
+++ b/Neolution.DotNet.Console/ConsoleAppBuilderExtensions.cs
@@ -34,21 +34,6 @@
         }
 
         /// <summary>
-        /// Configures the <see cref="ILoggingBuilder"/> delegate.
-        /// </summary>
-        /// <param name="loggingBuilderDelegate">The delegate that configures the <see cref="ILoggingBuilder"/>.</param>
-        /// <param name="context">The <see cref="ConsoleAppBuilderContext"/>.</param>
-        /// <returns>The <see cref="ILoggingBuilder"/> delegate.</returns>
-        private static Action<ILoggingBuilder> ConfigureLoggingBuilder(Action<ConsoleAppBuilderContext, ILoggingBuilder> loggingBuilderDelegate, ConsoleAppBuilderContext context)
-        {
-            return builder =>
-            {
-                builder.AddConfiguration(context.Configuration.GetSection("Logging"));
-                loggingBuilderDelegate(context, builder);
-            };
-        }
-
-        /// <summary>
         /// Specify the content root directory to be used by the host.
         /// </summary>
         /// <param name="consoleAppBuilder">The <see cref="IConsoleAppBuilder"/> to configure.</param>
@@ -73,6 +58,21 @@
                         new KeyValuePair<string, string>(HostDefaults.ContentRootKey, contentRoot),
                    });
                });
+        }
+
+        /// <summary>
+        /// Configures the <see cref="ILoggingBuilder"/> delegate.
+        /// </summary>
+        /// <param name="loggingBuilderDelegate">The delegate that configures the <see cref="ILoggingBuilder"/>.</param>
+        /// <param name="context">The <see cref="ConsoleAppBuilderContext"/>.</param>
+        /// <returns>The <see cref="ILoggingBuilder"/> delegate.</returns>
+        private static Action<ILoggingBuilder> ConfigureLoggingBuilder(Action<ConsoleAppBuilderContext, ILoggingBuilder> loggingBuilderDelegate, ConsoleAppBuilderContext context)
+        {
+            return builder =>
+            {
+                builder.AddConfiguration(context.Configuration.GetSection("Logging"));
+                loggingBuilderDelegate(context, builder);
+            };
         }
     }
 }

--- a/Neolution.DotNet.Console/ConsoleAppBuilderExtensions.cs
+++ b/Neolution.DotNet.Console/ConsoleAppBuilderExtensions.cs
@@ -30,7 +30,22 @@
                 throw new ArgumentNullException(nameof(consoleAppBuilder));
             }
 
-            return consoleAppBuilder.ConfigureServices((context, collection) => collection.AddLogging(builder => configureDelegate(context, builder)));
+            return consoleAppBuilder.ConfigureServices((context, collection) => collection.AddLogging(ConfigureLoggingBuilder(configureDelegate, context)));
+        }
+
+        /// <summary>
+        /// Configures the <see cref="ILoggingBuilder"/> delegate.
+        /// </summary>
+        /// <param name="loggingBuilderDelegate">The delegate that configures the <see cref="ILoggingBuilder"/>.</param>
+        /// <param name="context">The <see cref="ConsoleAppBuilderContext"/>.</param>
+        /// <returns>The <see cref="ILoggingBuilder"/> delegate.</returns>
+        private static Action<ILoggingBuilder> ConfigureLoggingBuilder(Action<ConsoleAppBuilderContext, ILoggingBuilder> loggingBuilderDelegate, ConsoleAppBuilderContext context)
+        {
+            return builder =>
+            {
+                builder.AddConfiguration(context.Configuration.GetSection("Logging"));
+                loggingBuilderDelegate(context, builder);
+            };
         }
 
         /// <summary>

--- a/Neolution.DotNet.Console/DotNetConsole.cs
+++ b/Neolution.DotNet.Console/DotNetConsole.cs
@@ -62,7 +62,6 @@
                 })
                 .ConfigureLogging((context, logging) =>
                 {
-                    logging.ClearProviders();
                     logging.AddNLog(context.Configuration);
                 });
 

--- a/Neolution.DotNet.Console/Neolution.DotNet.Console.csproj
+++ b/Neolution.DotNet.Console/Neolution.DotNet.Console.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
     <PackageReference Include="Neolution.CodeAnalysis" Version="2.5.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
The `Logging` section in appsettings.json was never added to the configuration of the app. Therefore, the app always used the Microsoft configured default minimum log level.

Also removed the `ClearProviders()` call and the `DetailedErrors` configuration value because they are unnecessary.