### PR TITLE
Skip V4 and jump to V5 instead

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -34,6 +34,6 @@ jobs:
           dotnet pack "Neolution.DotNet.Console\Neolution.DotNet.Console.csproj" --configuration ${{ env.BUILD_CONFIGURATION }} --no-build -p:PackageVersion=$NUGET_VERSION
 
       - name: Push NuGet package
-        run: dotnet nuget push --skip-duplicate -k $NUGET_AUTH_TOKEN  **/bin/Release/*.nupkg
+        run: dotnet nuget push -k $NUGET_AUTH_TOKEN  **/bin/Release/*.nupkg
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY_NEOLUTION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.0.0] - 2025-01-27
-
 ### Added
 
 - Added cancellation token support for commands

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ To help you kickstart your console application, we've provided a a [sample appli
 
 # Guides
 
-## Migrate from V3 to V4
+## Migrate from V3 to V5
+
+*Note: V4 was intentionally skipped, there is no V4 release.*
 
 To support cancellation tokens, the `IDotNetConsoleCommand` interface had to be changed: The `RunAsync` method now requires also a `CancellationToken` as a parameter. This change is breaking, so you will need to update your commands to reflect this change.
 


### PR DESCRIPTION
4.0.x numbers were already accidentally published to Nuget.org 2yrs ago and can't be used again
